### PR TITLE
Update manual link references to docs.ubuntu.com

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -53,8 +53,8 @@
                 <a href="#main-content">Jump to main content</a>
               </span>
               <ul class="p-navigation__links">
-                <li class="p-navigation__link"><a href="http://conjure-up.io/docs/en/users"><span class="p-link--external">User manual</span></a></li>
-                <li class="p-navigation__link"><a href="http://conjure-up.io/docs/en/developers"><span class="p-link--external">Developer manual</span></a></li>
+                <li class="p-navigation__link"><a href="https://docs.ubuntu.com/conjure-up/en/"><span class="p-link--external">User manual</span></a></li>
+                <li class="p-navigation__link"><a href="https://docs.ubuntu.com/conjure-up/en/dev-manual"><span class="p-link--external">Developer manual</span></a></li>
               </ul>
             </nav>
           </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,8 +11,8 @@ layout: "base"
     <div class="p-footer__inner">
         <ul class="p-inline-list u-no-margin--top">
           <li class="p-inline-list__item"><a href="/">Home</a></li>
-          <li class="p-inline-list__item"><a href="http://conjure-up.io/docs/en/users/">User manual</a></li>
-          <li class="p-inline-list__item"><a href="http://conjure-up.io/docs/en/developers">Developer manual</a></li>
+          <li class="p-inline-list__item"><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
+          <li class="p-inline-list__item"><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
           <li class="p-inline-list__item"><a class="p-link--external" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
           <li class="p-inline-list__item"><a class="p-link--external" href="https://askubuntu.com/questions/tagged/conjure-up">askubuntu.com</a></li>
           <li class="p-inline-list__item"><a class="p-link--external" href="https://rocket.ubuntu.com/channel/conjure-up">Rocketchat</a></li>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ layout: default
             <h3 class="p-heading-icon__title">User manual</h3>
           </div>
           <p>Refer to the user manual to get a more detailed guide in how to get up and running with conjure-up.</p>
-          <p><a class="p-link--external" href="http://conjure-up.io/docs/en/users/">Read the user manual</a></p>
+          <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">Read the user manual</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
Update link references to new docs.ubuntu.com location

## QA
- `npm run develop`
- Check links look nice and link correctly