### PR TITLE
Update the casing of conjure-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
   <div class="row u-vertically-center">
     <div class="col-6">
     <h1>Get started with big software, fast</h1>
-    <p><code>conjure-up</code> lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy it.</p>
+    <p>conjure-up lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy it.</p>
     </div>
     <div class="col-6 u-align--center u-hidden--small">
       <img src="{{ site.asset_path }}1abb8716-conjure-up-illustration.svg" alt="conjure-up illustration" />
@@ -28,7 +28,7 @@ layout: default
 
 <div class="p-strip--border-bottom">
   <div class="row">
-    <h2><code>conjure-up</code> spells</h2>
+    <h2>conjure-up spells</h2>
 
     <div class="col-12s u-equal-height">
       <div class="col-4 p-card--highlighted">
@@ -39,7 +39,7 @@ layout: default
           </div>
           <p><code>$ conjure-up kubernetes</code></p>
           <p>Get the Canonical Distribution of Kubernetes deployed and running all on a single machine. </p>
-          <p><a class="p-link--external" href="https://www.ubuntu.com/containers/kubernetes#getting-started-video">Kubernetes with <code>conjure-up</code></a></p>
+          <p><a class="p-link--external" href="https://www.ubuntu.com/containers/kubernetes#getting-started-video">Kubernetes with conjure-up</a></p>
         </div>
       </div>
 
@@ -51,7 +51,7 @@ layout: default
           </div>
           <p><code>$ conjure-up openstack</code></p>
           <p>Easily deploy real-world OpenStack on a single machine using LXD containers.</p>
-          <p><a class="p-link--external" href="https://www.ubuntu.com/download/cloud/conjure-up">OpenStack with <code>conjure-up</code></a></p>
+          <p><a class="p-link--external" href="https://www.ubuntu.com/download/cloud/conjure-up">OpenStack with conjure-up</a></p>
         </div>
       </div>
 
@@ -67,7 +67,7 @@ layout: default
 
 <div class="p-strip--x-light">
   <div class="row">
-    <h2>Getting help with <code>conjure-up</code></h2>
+    <h2>Getting help with conjure-up</h2>
     <div class="col-12 u-equal-height p-divider">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
@@ -75,7 +75,7 @@ layout: default
             <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg" alt="" />
             <h3 class="p-heading-icon__title">User manual</h3>
           </div>
-          <p>Refer to the user manual to get a more detailed guide in how to get up and running with <code>conjure-up</code>.</p>
+          <p>Refer to the user manual to get a more detailed guide in how to get up and running with conjure-up.</p>
           <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">Read the user manual</a></p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
   <div class="row u-vertically-center">
     <div class="col-6">
     <h1>Get started with big software, fast</h1>
-    <p>Conjure-up lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy it.</p>
+    <p><code>conjure-up</code> lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy it.</p>
     </div>
     <div class="col-6 u-align--center u-hidden--small">
       <img src="{{ site.asset_path }}1abb8716-conjure-up-illustration.svg" alt="conjure-up illustration" />
@@ -28,7 +28,7 @@ layout: default
 
 <div class="p-strip--border-bottom">
   <div class="row">
-    <h2>Conjure-up spells</h2>
+    <h2><code>conjure-up</code> spells</h2>
 
     <div class="col-12s u-equal-height">
       <div class="col-4 p-card--highlighted">
@@ -39,7 +39,7 @@ layout: default
           </div>
           <p><code>$ conjure-up kubernetes</code></p>
           <p>Get the Canonical Distribution of Kubernetes deployed and running all on a single machine. </p>
-          <p><a class="p-link--external" href="https://www.ubuntu.com/containers/kubernetes#getting-started-video">Kubernetes with conjure-up</a></p>
+          <p><a class="p-link--external" href="https://www.ubuntu.com/containers/kubernetes#getting-started-video">Kubernetes with <code>conjure-up</code></a></p>
         </div>
       </div>
 
@@ -51,7 +51,7 @@ layout: default
           </div>
           <p><code>$ conjure-up openstack</code></p>
           <p>Easily deploy real-world OpenStack on a single machine using LXD containers.</p>
-          <p><a class="p-link--external" href="https://www.ubuntu.com/download/cloud/conjure-up">OpenStack with conjure-up</a></p>
+          <p><a class="p-link--external" href="https://www.ubuntu.com/download/cloud/conjure-up">OpenStack with <code>conjure-up</code></a></p>
         </div>
       </div>
 
@@ -67,7 +67,7 @@ layout: default
 
 <div class="p-strip--x-light">
   <div class="row">
-    <h2>Getting help with conjure-up</h2>
+    <h2>Getting help with <code>conjure-up</code></h2>
     <div class="col-12 u-equal-height p-divider">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon">
@@ -75,7 +75,7 @@ layout: default
             <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg" alt="" />
             <h3 class="p-heading-icon__title">User manual</h3>
           </div>
-          <p>Refer to the user manual to get a more detailed guide in how to get up and running with conjure-up.</p>
+          <p>Refer to the user manual to get a more detailed guide in how to get up and running with <code>conjure-up</code>.</p>
           <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">Read the user manual</a></p>
         </div>
       </div>
@@ -97,7 +97,7 @@ layout: default
             <img class="p-heading-icon__img" width="100" src="{{ site.asset_path }}471ad75a-rocketchat.svg" alt="" />
             <h3 class="p-heading-icon__title">Rocketchat</h3>
           </div>
-          <p>Join the Rocketchat channel if you&rsquo;re having problems with getting conjure-up running.</p>
+          <p>Join the Rocketchat channel if you&rsquo;re having problems with getting <code>conjure-up</code> running.</p>
           <p><a class="p-link--external" href="https://rocket.ubuntu.com/channel/conjure-up">Go to ubuntu.rocketchat</a></p>
         </div>
       </div>
@@ -108,7 +108,7 @@ layout: default
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2>How to contribute to conjure-up</h2>
+      <h2>How to contribute to <code>conjure-up</code></h2>
     </div>
     <div class="row">
       <p class="col-6">Create your own spells from scratch using the developer manual or build off existing spells via GitHub.</p>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ layout: default
             <img class="p-heading-icon__img" width="100" src="{{ site.asset_path }}471ad75a-rocketchat.svg" alt="" />
             <h3 class="p-heading-icon__title">Rocketchat</h3>
           </div>
-          <p>Join the Rocketchat channel if you&rsquo;re having problems with getting <code>conjure-up</code> running.</p>
+          <p>Join the Rocketchat channel if you&rsquo;re having problems with getting conjure-up running.</p>
           <p><a class="p-link--external" href="https://rocket.ubuntu.com/channel/conjure-up">Go to ubuntu.rocketchat</a></p>
         </div>
       </div>
@@ -108,7 +108,7 @@ layout: default
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2>How to contribute to <code>conjure-up</code></h2>
+      <h2>How to contribute to conjure-up</h2>
     </div>
     <div class="row">
       <p class="col-6">Create your own spells from scratch using the developer manual or build off existing spells via GitHub.</p>


### PR DESCRIPTION
## Done
Updated all references to `conjure-up` to a lowercase and codified it so it doesn't look odd at the beginning of a sentence.

## QA
- Pull the code and run `npm run develop`
- Go to http://127.0.0.1:4000/
- Check the homepage looks ok

## Details
Fixes https://github.com/canonical-websites/conjure-up.io/issues/15

## Screenshot
![conjure-up io](https://cloud.githubusercontent.com/assets/1413534/25976157/e5a5e9b6-36aa-11e7-89c1-a9e64fdbb6bc.png)


