### PR TITLE
Replace circular link to ubuntu.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ layout: default
           </div>
           <p><code>$ conjure-up kubernetes</code></p>
           <p>Get the Canonical Distribution of Kubernetes deployed and running all on a single machine. </p>
-          <p><a class="p-link--external" href="https://www.ubuntu.com/containers/kubernetes#getting-started-video">Kubernetes with conjure-up</a></p>
+          <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/walkthrough">Kubernetes with conjure-up</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
## Done
Updated a link for kubernetes with conjure-up

## QA
Check that the link matches the copy doc: https://docs.google.com/a/canonical.com/document/d/1gdJCOZORvgsCDcZq2et-vaP8WUaJXgjJvXsUulmeLJw/edit

## Issue / Card
Fixes https://github.com/canonical-websites/conjure-up.io/issues/19
