### PR TITLE
Replace Rocket chat with IRC

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,11 @@ layout: default
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" width="100" src="{{ site.asset_path }}471ad75a-rocketchat.svg" alt="" />
-          <h3 class="p-heading-icon__title">Rocketchat</h3>
+          <img class="p-heading-icon__img" width="100" src="{{ site.asset_path }}d3ae9c8e-irc-icon-circle.svg" alt="" />
+          <h3 class="p-heading-icon__title"><abbr title="Internet Relay Chat">IRC</abbr></h3>
         </div>
-        <p>Join the Rocketchat channel if you&rsquo;re having problems with getting conjure-up running.</p>
-        <p><a class="p-link--external" href="https://rocket.ubuntu.com/channel/conjure-up">Go to ubuntu.rocketchat</a></p>
+        <p>Join the <code>#conjure-up</code> channel on <code>irc.freenode.net</code> if you&rsquo;re having problems with getting conjure-up running.</p>
+        <p><a class="p-link--external" href="https://webchat.freenode.net/">Go to webchat.freenode.net</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done
Replaced the Rocket chat section to IRC.

## QA
- Run `./run`
- Go to http://0.0.0.0:8005/
- Scroll down to the "Getting help with conjure-up" section
- Check that the left part is IRC not Rocket chat

## Issue / Card
Fixes https://github.com/canonical-websites/conjure-up.io/issues/22
