### PR TITLE
Fixed neutral button with icon styling

### DIFF
--- a/static/sass/_patterns_buttons.scss
+++ b/static/sass/_patterns_buttons.scss
@@ -5,7 +5,14 @@
 
 @mixin button-neutral-icon {
   .p-button--neutral-icon {
-    @include vf-button-pattern;
+    @extend %vf-button-base;
+    @include vf-button-pattern (
+      $button-disabled-border-color: $color-mid-light,
+      $button-border-color: $color-mid-light,
+      $button-hover-background-color: $color-light,
+      $button-hover-border-color: $color-mid-light
+    );
+
     align-items: center;
     background: none;
     display: inline-flex;


### PR DESCRIPTION
## Done

- Fixed styling bug of bespoke `.p-button--neutral-icon`

## QA

- `./run`
- http://0.0.0.0:8005/
- Check that the GitHub button at the bottom looks good

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1671
