### PR TITLE
23: Add 64-bit only clarifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,9 @@ layout: default
 <div class="p-strip--accent is-shallow">
   <div class="row">
     <div class="col-12">
-      <h2>Get started</h2>
-      <ul class="p-list p-heading--four">
+      <h2 class="u-no-margin--bottom">Get started</h2>
+      <p class="u-no-padding--top"><small>(64-bit only)</small></p>
+      <ul class="p-list p-heading--four u-no-padding--top">
         <li class="p-list__item"><code>$ sudo snap install conjure-up --classic</code></li>
         <li class="p-list__item"><code>$ conjure-up</code></li>
       </ul>


### PR DESCRIPTION
## Done

- Added "(64-bit only)" under the Get Started header

## QA

- Pull code
- `./run`
- Check that "(64-bit only)" small print is below the "Get started" header

## Issue / Card

Fixes #23 