### PR TITLE
Update to Vanilla v1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/canonical-websites/conjure-up.io#readme",
   "devDependencies": {
-    "vanilla-framework": "1.7.0"
+    "vanilla-framework": "1.8.0"
   },
   "dependencies": {
     "watch-cli": "^0.2.2",

--- a/static/sass/_patterns_buttons.scss
+++ b/static/sass/_patterns_buttons.scss
@@ -14,7 +14,6 @@
     );
 
     align-items: center;
-    background: none;
     display: inline-flex;
     padding: .3rem 1.5rem;
     width: auto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,9 +2854,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0.tgz#ae198e46f0823ee2d316bcd2783e4846df676728"
+vanilla-framework@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done
- Updated version of site to v1.8
- Updated 'conjure-up spells' cards to default
- Updated 'View on GitHub' to use neutral button styling

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8005/](http://0.0.0.0:8005/)
4. Compare with [live](https://conjure-up.io/) and ensure that the site looks the same (or better)
